### PR TITLE
MovieClip bounds fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/stage-inspector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1979,7 +1979,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2000,12 +2001,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2020,17 +2023,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2147,7 +2153,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2159,6 +2166,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2173,6 +2181,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2180,12 +2189,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2204,6 +2215,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2284,7 +2296,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2296,6 +2309,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2381,7 +2395,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2417,6 +2432,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2436,6 +2452,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2479,12 +2496,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/stage-inspector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Debugging tool to help figure out layout issues when using CreateJS",
   "main": "dist/stage-inspector.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ This module was developed using the 0.8.2 of CreateJS/EaselJS.
 ## Usage
 Since this is a debugging tool, it is expected to be primarily used through the browser's console.  So, while a consuming project may not need to create or use a StageInspector instance, it should import the module to ensure it's included in the consuming project's bundle and therefore available at runtime.  Such as with:
 ```
-import StageInspector from 'stage-inspector'; // eslint-disable-line no-unused-vars
+import StageInspector from '@curriculumassociates/stage-inspector'; // eslint-disable-line no-unused-vars
 ```
 
 Once the module is imported, instances of the StageInspector class can be created either in that file or in the console since the StageInspector class is made available through `window.StageInspector`.  To create an instance, the CreateJS Stage instance that it should inspect needs to be provided:

--- a/src/index.js
+++ b/src/index.js
@@ -471,7 +471,19 @@ export default class StageInspector {
 
       const includeObj = !this._filters || this._checkFilters(obj);
       if (includeObj) {
-        let bounds = obj.getBounds();
+        let bounds;
+        try {
+          if (obj.frameBounds && obj.frameBounds.length > 0 && Number.isInteger(obj.currentFrame) && obj.currentFrame >= obj.frameBounds.length) {
+            // If a createjs.MovieClip is told to gotoAndPlay without being stopped, it will end up with a currentFrame 1 index off the end of the frameBounds array.
+            // That results in getBounds throwing an exception when it tries to copy the frameBounds at the current frame.  So, instead of letting that happen, just use
+            // the last entry in the frameBounds array when that case is detected.
+            bounds = obj.frameBounds[obj.frameBounds.length - 1];
+          } else {
+            bounds = obj.getBounds();
+          }
+        } catch (err) {
+          // ignore, this is mainly for the case of undefined bounds
+        }
         if (!bounds) {
           return;
         }


### PR DESCRIPTION
Handling the case of a MovieClip having its currentFrame index off the end of the frameBounds array after a gotoAndPlay and other cases that can cause getBounds to throw an exception